### PR TITLE
Fix #2 and #3

### DIFF
--- a/pywinservicemanager/tests/TestFailureActionConfigurationResetPeriodType.py
+++ b/pywinservicemanager/tests/TestFailureActionConfigurationResetPeriodType.py
@@ -21,7 +21,7 @@ class TestFailureActionConfigurationResetPeriodType(unittest.TestCase):
         self.assertEquals(t.Win32Value(), value)
 
     def TestInitWithParametersOfNotValidValue(self):
-        self.assertRaises(ValueError, FailureActionConfigurationResetPeriodType, long(1))
+        self.assertRaises(ValueError, FailureActionConfigurationResetPeriodType, float(1))
 
     def TestInitWithCorrectParameters(self):
         value = int(1)

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(name='pywinservicemanager',
       description='Windows Service Manager Module that wraps for the win32service api',
       packages=find_packages(),
       long_description=open('README.rst').read(),
-      install_requires=['pywin32>=219'],
+      install_requires=['pypiwin32>=219'],
       tests_require=['mock', 'nose'])


### PR DESCRIPTION
Please see the issues. Nosetests still pass on Python2.7 with this PR.

Note that we cannot require pywin32 version 220 yet; PyPI has it just for Python3.6 so far. So sticking to >= 219.

